### PR TITLE
Test and fix for invalid JSON crash

### DIFF
--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -317,4 +317,20 @@ describe 'Integration' do
       end
     end
   end
+
+  context "given invalid JSON as input" do
+
+    it 'should not crash' do
+      messages  = em_stream do |websocket, messages|
+        websocket.callback do
+          websocket.send("{ event: 'pusher:subscribe', data: { channel: 'MY_CHANNEL'} }23123")
+          EM.next_tick { EM.stop }
+        end if messages.one?
+
+      end
+
+      EM.run { new_websocket.tap { |u| u.stream { EM.next_tick { EM.stop } } }}
+    end
+
+  end
 end


### PR DESCRIPTION
Hi,

this is a proposed fix and test for #31. It catches all exceptions, but handles JSON::ParserError for better error messages.

Sadly, I couldn't find out what Pusher would actually send in that case :/, so I'll just put this up for discussion.
