### PR TITLE
Updated docs for using Slanger with SSL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Slanger supports several configuration options, which can be supplied as command
 
 -b or --webhook_url URL for webhooks. This argument is optional, if given webhook callbacks will be made http://pusher.com/docs/webhooks
 
--c or --cert_file Certificate file for SSL support. This argument is optional, if given, SSL will be enabled
+-c or --cert_chain_file Certificate chain file or the Certificate file for SSL support. This argument is optional, if given, SSL will be enabled
 
 -v or --[no-]verbose This makes Slanger run verbosely, meaning WebSocket frames will be echoed to STDOUT. Useful for debugging
 </pre>


### PR DESCRIPTION
Let me first thank you for this awesome work. I was implementing Slanger for one of my customer & noticed a few things while changing it to SSL.

For Slanger to work under SSL, the default WSS port of Pusher library needed to be changed from 443 to 8080. I didn't find it in the docs. So this fix would definitely save some time for new users :).

Also the websocket didnt run successfully on using 'Certificate chain file' for SSL support (Slanger will not show any error in this case, but the websocket request always remain in the 'pending' state). Instead I used 'Certificate file' for the '-c' param.This worked. 

Is this a bug ? If so it would be better to change the param '--cert_chain_file' to something like '--cert_file' for more clarity. (I believe the '--cert_chain_file' param was borrowed straight from Event Machine. And most CA doesn't provide a Certificate chain file either)
