### PR TITLE
Issue #84, modify api_server.rb to conform to new Pusher Rest API

### DIFF
--- a/lib/slanger/api_server.rb
+++ b/lib/slanger/api_server.rb
@@ -19,41 +19,52 @@ module Slanger
     error(Signature::AuthenticationError) { |c| halt 401, "401 UNAUTHORIZED\n" }
 
     post '/apps/:app_id/events' do
-      # authenticate request. exclude 'channel_id' and 'app_id' included by sinatra but not sent by Pusher.
-      # Raises Signature::AuthenticationError if request does not authenticate.
-      Signature::Request.new('POST', env['PATH_INFO'], params.except('channel_id', 'app_id')).
-        authenticate { |key| Signature::Token.new key, Slanger::Config.secret }
-
-      f = Fiber.current
+      authenticate
 
       # Event and channel data are now serialized in the JSON data
       # So, extract and use it
       data = JSON.parse(request.body.read.tap{ |s| s.force_encoding('utf-8')})
 
       # Send event to each channel
-      data["channels"].each { |channel|
-        
-        # Publish the event in Redis and translate the result into an HTTP
-        # status to return to the client.
-        Slanger::Redis.publish(channel, payload(channel, data)).tap do |r|
-          r.callback { f.resume [202, {}, "202 ACCEPTED\n"] }
-          r.errback  { f.resume [500, {}, "500 INTERNAL SERVER ERROR\n"] }
-        end
-      }
+      data["channels"].each { |channel| publish(channel, data['name'], data['data']) }
       
+    end
+
+    post '/apps/:app_id/channels/:channel_id/events' do
+      authenticate
+      
+      publish(params[:channel_id], params['name'],  request.body.read.tap{ |s| s.force_encoding('utf-8') })
+    end
+    
+    def payload(channel, event, data)
+      {
+        event:     event,
+        data:      data,
+        channel:   channel,
+        socket_id: params[:socket_id]
+      }.select { |_,v| v }.to_json
+    end
+
+    def authenticate
+      # authenticate request. exclude 'channel_id' and 'app_id' included by sinatra but not sent by Pusher.
+      # Raises Signature::AuthenticationError if request does not authenticate.
+      Signature::Request.new('POST', env['PATH_INFO'], params.except('channel_id', 'app_id')).
+        authenticate { |key| Signature::Token.new key, Slanger::Config.secret }
+    end
+  
+    def publish(channel, event, data)
+      f = Fiber.current
+
+      # Publish the event in Redis and translate the result into an HTTP
+      # status to return to the client.
+      Slanger::Redis.publish(channel, payload(channel, event, data)).tap do |r|
+        r.callback { f.resume [202, {}, "202 ACCEPTED\n"] }
+        r.errback  { f.resume [500, {}, "500 INTERNAL SERVER ERROR\n"] }
+      end
+
       Fiber.yield
     end
 
-    def payload(channel, data)
-      payload = {
-        event:     data['name'],
-        data:      data['data'],
-        channel:   channel,
-        socket_id: params[:socket_id]
-      }
-
-      Hash[payload.reject { |_,v| v.nil? }].to_json
-    end
   end
 end
 


### PR DESCRIPTION
Pusher changed the Rest API so that the channel and event ID are part of the JSON payload rather than in the URl. This allows for the new (?) pattern of sending an event to multiple channels. 

```
So, change to listen to the new endpoint.
Decode the payload
For each channel in send event
```
