### PR TITLE
Add --pid_file command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Slanger supports several configuration options, which can be supplied as command
 -c or --cert_chain_file Certificate chain file or the Certificate file for SSL support. This argument is optional, if given, SSL will be enabled
 
 -v or --[no-]verbose This makes Slanger run verbosely, meaning WebSocket frames will be echoed to STDOUT. Useful for debugging
+
+--pid_file  The path to a file you want slanger to write it's PID to. Optional.
 </pre>
 
 

--- a/bin/slanger
+++ b/bin/slanger
@@ -59,6 +59,10 @@ OptionParser.new do |opts|
     options[:debug] = v
   end
 
+  opts.on '--pid_file PIDFILE', "The slanger process ID file name." do |k|
+    options[:pid_file] = k
+  end
+
   opts.parse!
 
   %w<app_key secret>.each do |parameter|
@@ -86,6 +90,12 @@ EM.kqueue
 EM.run do
   File.tap { |f| require f.expand_path(f.join(f.dirname(__FILE__),'..', 'slanger.rb')) }
   Slanger::Config.load options
+
+  # Write PID to file
+  unless options[:pid_file].nil?
+    File.open(options[:pid_file], 'w') { |f| f.puts Process.pid }
+  end
+
   Slanger::Service.run
 
   puts "\n"


### PR DESCRIPTION
While writing a init script for slanger (do you have an init script and would like to share?), I had problems getting the PID of my slanger service. Using a --require script is possible but this pull request makes it easier to kill the process after starting it in the background.
