### PR TITLE
Updating sinatra/rack dependencies 

### DIFF
--- a/slanger.gemspec
+++ b/slanger.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency                'signature',        '~> 0.1.6'
   s.add_dependency                'activesupport',    '~> 3.1'
   s.add_dependency                'glamazon',         '~> 0.3.1'
-  s.add_dependency                'sinatra',          '~> 1.2.6'
+  s.add_dependency                'sinatra',          '~> 1.4.2'
   s.add_dependency                'thin',             '~> 1.2.11'
   s.add_dependency                'em-http-request',  '~> 0.3.0'
 


### PR DESCRIPTION
Fix sinatra/rack dependencies in slanger.gemspec:

<pre>
$ git diff slanger.gemspec | grep sinatra

-  s.add_dependency                'sinatra',          '~> 1.2.6'
+  s.add_dependency                'sinatra',          '~> 1.4.2'
</pre>


follow the error I got :

<pre>
lsoave@ubuntu:~/rails/github/elasticrepo$ slanger --app_key 765ec374ae0a69f4ce44 --secret your-pusher-secret
/home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1990:in `raise_if_conflicts': Unable to activate sinatra-1.2.9, because rack-1.5.2 conflicts with rack (< 1.5, ~> 1.1) (Gem::LoadError)
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1163:in `activate'
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1199:in `block in activate_dependencies'
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1185:in `each'
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1185:in `activate_dependencies'
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/specification.rb:1167:in `activate'
    from /home/lsoave/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_gem.rb:48:in `gem'
    from /home/lsoave/.rvm/gems/ruby-2.0.0-p0@rails-4.0.0/bin/slanger:22:in `<main>'
    from /home/lsoave/.rvm/gems/ruby-2.0.0-p0@rails-4.0.0/bin/ruby_noexec_wrapper:14:in `eval'
    from /home/lsoave/.rvm/gems/ruby-2.0.0-p0@rails-4.0.0/bin/ruby_noexec_wrapper:14:in `<main>'
lsoave@ubuntu:~/rails/github/elasticrepo$</pre>
