### PR TITLE
Use '# enconding: utf-8' instead of '-Ku' in slager.rb.

### DIFF
--- a/bin/slanger
+++ b/bin/slanger
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby -Ku
+#!/usr/bin/env ruby
+# encoding: utf-8
 
 require 'optparse'
 require 'bundler/setup'


### PR DESCRIPTION
slanger.rb now uses a shebang like this:

```
#!/usr/bin/env ruby -Ku
```

But passing arguments to `env` in this way does not work in linux. See more about it [here](http://elliotth.blogspot.com.ar/2006/04/lesson-about-using-env1-in-script.html)

Same could be done using just `# encoding: utf-8`
