### PR TITLE
Implement pusher_pong.

### DIFF
--- a/lib/slanger/handler.rb
+++ b/lib/slanger/handler.rb
@@ -53,7 +53,7 @@ module Slanger
     end
 
     def pusher_ping(msg)
-      send_payload nil, 'pusher:ping'
+      send_payload nil, 'pusher:pong'
     end
 
     def pusher_pong msg; end


### PR DESCRIPTION
I have an Android application that connects to Slanger. The application sends a `ping` message to keep the connection alive. Slanger should response with a `pong` to these messages, otherwise the pusher client library closes the connection.
