### PR TITLE
Check client protocol version and ignore unrecognized/unsupported versions

### DIFF
--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -26,6 +26,33 @@ describe 'Integration' do
     end
   end
 
+  context "connect with valid protocol version" do
+    it "should connect successfuly" do
+      messages = em_stream do |websocket, messages|
+        websocket.callback { EM.stop }
+      end
+      messages.should have_attributes connection_established: true, id_present: true
+    end
+  end
+
+  context "connect with invalid protocol version" do
+    it "should not connect successfuly with version bigger than supported" do
+      messages = em_stream(protocol: "20") do |websocket, messages|
+        websocket.callback { EM.stop }
+      end
+      messages.should have_attributes connection_established: false, id_present: false,
+        last_event: 'pusher:error'
+    end
+
+    it "should not connect successfuly without specified version" do
+      messages = em_stream(protocol: nil) do |websocket, messages|
+        websocket.callback { EM.stop }
+      end
+      messages.should have_attributes connection_established: false, id_present: false,
+        last_event: 'pusher:error'
+    end
+  end
+
   context "given invalid JSON as input" do
     it 'should not crash' do
       messages  = em_stream do |websocket, messages|

--- a/spec/slanger_helper_methods.rb
+++ b/spec/slanger_helper_methods.rb
@@ -38,8 +38,8 @@ module SlangerHelperMethods
   end
 
   def new_websocket opts = {}
-    opts = { key: Pusher.key }.update opts
-    uri = "ws://0.0.0.0:8080/app/#{opts[:key]}?client=js&version=1.8.5"
+    opts = { key: Pusher.key, protocol: 7 }.update opts
+    uri = "ws://0.0.0.0:8080/app/#{opts[:key]}?client=js&version=1.8.5&protocol=#{opts[:protocol]}"
 
     EM::HttpRequest.new(uri).get.tap { |ws| ws.errback &errback }
   end


### PR DESCRIPTION
Connections with missing or unsupported protocol versions get disconnected and a proper error is returned according to [pusher error codes](http://pusher.com/docs/pusher_protocol).
