### PR TITLE
Add newer ruby versions to travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 
 rvm:
-  - 1.9.2
   - 1.9.3
+  - 2.0.0
+  - 2.1.0
 
 env:
   - DB=redis
 
 services:
   - redis-server
-


### PR DESCRIPTION
Remove 1.9.2 as it was failing due to a bundler dependancy error and add 2.0.0 and 2.1.0 which are supported as of #130
This will make good PRs not appear as failing because of the 1.9.2 errors on travis.
