### PR TITLE
Webhook signature and content type fix for the pusher protocol version 2.2.2

### DIFF
--- a/lib/slanger/webhook.rb
+++ b/lib/slanger/webhook.rb
@@ -10,11 +10,16 @@ module Slanger
         time_ms: Time.now.strftime('%s%L'), events: [payload]
       }.to_json
 
-      digest   = OpenSSL::Digest::SHA256.new
-      hmac     = OpenSSL::HMAC.hexdigest(digest, Slanger::Config.secret, payload)
+      digest        = OpenSSL::Digest::SHA256.new
+      hmac          = OpenSSL::HMAC.hexdigest(digest, Slanger::Config.secret, payload)
+      content_type  = 'application/json'
 
       EM::HttpRequest.new(Slanger::Config.webhook_url).
-        post(body: payload, head: { "X-Pusher-Key" => Slanger::Config.app_key, "X-Pusher-Secret" => hmac })
+        post(body: payload, head: { 
+          "X-Pusher-Key" => Slanger::Config.app_key, 
+          "X-Pusher-Signature" => hmac, 
+          "Content-Type" => content_type 
+        })
         # TODO: Exponentially backed off retries for errors
     end
 

--- a/spec/unit/webhook_spec.rb
+++ b/spec/unit/webhook_spec.rb
@@ -25,7 +25,8 @@ describe 'Slanger::Webhook' do
       stub_request(:post, Slanger::Config.webhook_url).
         with(body: payload, headers: {
             "X-Pusher-Key"    => Slanger::Config.app_key,
-            "X-Pusher-Secret" => hmac
+            "X-Pusher-Signature" => hmac,
+            "Content-Type" => 'application/json'
         }).
         to_return(:status => 200, :body => {}.to_json, :headers => {})
 
@@ -34,7 +35,8 @@ describe 'Slanger::Webhook' do
       WebMock.should have_requested(:post, Slanger::Config.webhook_url).
         with(body: payload, headers: {
             "X-Pusher-Key"    => Slanger::Config.app_key,
-            "X-Pusher-Secret" => hmac
+            "X-Pusher-Signature" => hmac,
+            "Content-Type" => 'application/json'
         })
     end
   end


### PR DESCRIPTION
The current pusher implementation sends and expects the webhook headers to contain X-Pusher-Signature (as opposed to X-Pusher-Secret) and the content type of 'application/json'. Without these the current pusher gem refuses to accept incoming web hook requests from Slanger and treats them invalid.

I've fixed the webhook implementation in Slanger and altered the tests to match. Hope this helps. :)
