### PR TITLE
Optional config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ Of course you could proxy all requests to `ws.example.com` to port 8080 of your 
 Slanger supports several configuration options, which can be supplied as command line arguments at invocation. You can also supply a yaml file containing config options. If you use the config file in combination with other configuration options, the values passed on the command line will win. Allows running multiple instances with only a few differences easy.
 
 ```
--k or --app_key This is the Pusher app key you want to use. This is a required argument
+-k or --app_key This is the Pusher app key you want to use. This is a required argument on command line or in optional config file
 
--s or --secret This is your Pusher secret. This is a required argument
+-s or --secret This is your Pusher secret. This is a required argument on command line or in optional config file
 
--C or --config_file Path to Yaml file that contains any desired configuration options
+-C or --config_file Path to Yaml file that can contain all or some of the configuration options, including required arguments
 
 -r or --redis_address An address where there is a Redis server running. This is an optional argument and defaults to redis://127.0.0.1:6379/0
 

--- a/README.md
+++ b/README.md
@@ -161,12 +161,14 @@ Of course you could proxy all requests to `ws.example.com` to port 8080 of your 
 
 # Configuration Options
 
-Slanger supports several configuration options, which can be supplied as command line arguments at invocation.
+Slanger supports several configuration options, which can be supplied as command line arguments at invocation. You can also supply a yaml file containing config options. If you use the config file in combination with other configuration options, the values passed on the command line will win. Allows running multiple instances with only a few differences easy.
 
 ```
 -k or --app_key This is the Pusher app key you want to use. This is a required argument
 
 -s or --secret This is your Pusher secret. This is a required argument
+
+-C or --config_file Path to Yaml file that contains any desired configuration options
 
 -r or --redis_address An address where there is a Redis server running. This is an optional argument and defaults to redis://127.0.0.1:6379/0
 

--- a/bin/slanger
+++ b/bin/slanger
@@ -7,9 +7,7 @@ require 'eventmachine'
 require 'yaml'
 require 'active_support/core_ext/hash'
 
-options = {
-  config_file:''
-  }
+options = {}
 
 
 OptionParser.new do |opts|
@@ -75,7 +73,7 @@ OptionParser.new do |opts|
 
   opts.parse!
 
-  if File.exists? options[:config_file]
+  if options[:config_file] and File.exists? options[:config_file]
     config_file_contents = YAML::load(File.open(options[:config_file]))
     options.reverse_merge! config_file_contents.deep_symbolize_keys!
   end

--- a/bin/slanger
+++ b/bin/slanger
@@ -4,10 +4,11 @@
 require 'optparse'
 require 'bundler/setup'
 require 'eventmachine'
+require 'yaml'
+require 'active_support/core_ext/hash'
 
 options = {
-  api_host: '0.0.0.0', api_port: '4567', websocket_host: '0.0.0.0',
-  websocket_port: '8080', debug: false, redis_address: 'redis://0.0.0.0:6379/0'
+  config_file:''
   }
 
 
@@ -23,6 +24,10 @@ OptionParser.new do |opts|
 
   opts.on '-s', '--secret SECRET', "Pusher application secret. This parameter is required." do |k|
     options[:secret] = k
+  end
+
+  opts.on '-C', '--config_file FILE', "Path to Yaml file that contains any desired configuration options." do |k|
+    options[:config_file] = k
   end
 
   opts.on '-r', '--redis_address URL', "Address to bind to (Default: redis://127.0.0.1:6379/0)" do |h|
@@ -69,6 +74,11 @@ OptionParser.new do |opts|
   end
 
   opts.parse!
+
+  if File.exists? options[:config_file]
+    config_file_contents = YAML::load(File.open(options[:config_file]))
+    options.reverse_merge! config_file_contents.deep_symbolize_keys!
+  end
 
   %w<app_key secret>.each do |parameter|
     unless options[parameter.to_sym]
@@ -123,6 +133,6 @@ EM.run do
   puts "Running Slanger v.#{Slanger::VERSION}"
   puts "\n"
 
-  puts "Slanger API server listening on port #{options[:api_port]}"
-  puts "Slanger WebSocket server listening on port #{options[:websocket_port]}"
+  puts "Slanger API server listening on port #{Slanger::Config.api_port}"
+  puts "Slanger WebSocket server listening on port #{Slanger::Config.websocket_port}"
 end

--- a/bin/slanger
+++ b/bin/slanger
@@ -16,15 +16,15 @@ OptionParser.new do |opts|
     exit
   end
 
-  opts.on '-k', '--app_key APP_KEY', "Pusher application key. This parameter is required." do |k|
+  opts.on '-k', '--app_key APP_KEY', "Pusher application key. This parameter is required on command line or in optional config file." do |k|
     options[:app_key] = k
   end
 
-  opts.on '-s', '--secret SECRET', "Pusher application secret. This parameter is required." do |k|
+  opts.on '-s', '--secret SECRET', "Pusher application secret. This parameter is required on command line or in optional config file." do |k|
     options[:secret] = k
   end
 
-  opts.on '-C', '--config_file FILE', "Path to Yaml file that contains any desired configuration options." do |k|
+  opts.on '-C', '--config_file FILE', "Path to Yaml file that can contain all configuration options, including required ones." do |k|
     options[:config_file] = k
   end
 

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,0 +1,10 @@
+# Basic config file example for use as command line option
+# Can set any options in here and pass file as option
+# Command line flags will override these settings if you need granularity
+activity_timeout: 150
+api_port: 1234
+app_key: my_pusher_key
+secret: my_pusher_secret
+tls_options:
+  cert_chain_file: 'mycert.cer'
+  private_key_file: 'my.key'


### PR DESCRIPTION
Allows service start script to take an optional config file to hold all the start up options instead of specifying them all on command line. 

Can be used in conjunction with other flags to set some or all the startup config options.

Config options specified via flag on command line will take precedence over items in config file.