### PR TITLE
Add webhook support for presence channels

### DIFF
--- a/lib/slanger/api/request_validation.rb
+++ b/lib/slanger/api/request_validation.rb
@@ -10,7 +10,7 @@ module Slanger
       end
 
       def data
-        @data ||= JSON.parse(body["data"] || params["data"])
+        @data ||= JSON.load(body["data"] || params["data"])
       end
 
       def body
@@ -85,7 +85,7 @@ module Slanger
       end
 
       def assert_valid_json!(string)
-        JSON.parse(string)
+        JSON.load(string)
       rescue JSON::ParserError
         raise Slanger::InvalidRequest.new("Invalid request body: #{raw_body}")
       end

--- a/lib/slanger/connection.rb
+++ b/lib/slanger/connection.rb
@@ -7,7 +7,7 @@ module Slanger
     end
 
     def send_message m
-      msg = JSON.parse m
+      msg = JSON.load m
       s = msg.delete 'socket_id'
       socket.send msg.to_json unless s == socket_id
     end

--- a/lib/slanger/handler.rb
+++ b/lib/slanger/handler.rb
@@ -24,9 +24,9 @@ module Slanger
     # Dispatches message handling to method with same name as
     # the event name
     def onmessage(msg)
-      msg = JSON.parse(msg)
+      msg = JSON.load(msg)
 
-      msg['data'] = JSON.parse(msg['data']) if msg['data'].is_a? String
+      msg['data'] = JSON.load(msg['data']) if msg['data'].is_a? String
 
       event = msg['event'].gsub(/\Apusher:/, 'pusher_')
 

--- a/lib/slanger/presence_channel.rb
+++ b/lib/slanger/presence_channel.rb
@@ -36,7 +36,7 @@ module Slanger
           Slanger::Webhook.post name: 'channel_occupied', channel: channel_id if value == 1
         end
 
-      channel_data = JSON.parse msg['data']['channel_data']
+      channel_data = JSON.load msg['data']['channel_data']
       public_subscription_id = SecureRandom.uuid
 
       # Send event about the new subscription to the Redis slanger:connection_notification Channel.

--- a/lib/slanger/redis.rb
+++ b/lib/slanger/redis.rb
@@ -24,7 +24,7 @@ module Slanger
     def subscriber
       @subscriber ||= new_connection.pubsub.tap do |c|
         c.on(:message) do |channel, message|
-          message = JSON.parse message
+          message = JSON.load message
           c = Channel.from message['channel']
           c.dispatch message, channel
         end


### PR DESCRIPTION
Add the support for webhooks to be fired for presence channels too.

Events that are implemented for presence channels:
channel_occupied
channel_vacated
member_added
member_removed