### PR TITLE
Check if eventmachine epoll/kqueue is supported

### DIFF
--- a/bin/slanger
+++ b/bin/slanger
@@ -99,8 +99,10 @@ end
 
 STDOUT.sync = true
 
-EM.epoll
-EM.kqueue
+case
+when EM.epoll?  then EM.epoll
+when EM.kqueue? then EM.kqueue
+end
 
 EM.run do
   File.tap { |f| require f.expand_path(f.join(f.dirname(__FILE__),'..', 'slanger.rb')) }

--- a/lib/slanger/web_socket_server.rb
+++ b/lib/slanger/web_socket_server.rb
@@ -4,8 +4,10 @@ require 'em-websocket'
 module Slanger
   module WebSocketServer
     def run
-      EM.epoll
-      EM.kqueue
+      case
+      when EM.epoll?  then EM.epoll
+      when EM.kqueue? then EM.kqueue
+      end
 
       EM.run do
         options = {

--- a/slanger.rb
+++ b/slanger.rb
@@ -9,8 +9,10 @@ require File.join(File.dirname(__FILE__), 'lib', 'slanger', 'version')
 
 module Slanger; end
 
-EM.epoll
-EM.kqueue
+case
+when EM.epoll?  then EM.epoll
+when EM.kqueue? then EM.kqueue
+end
 
 File.tap do |f|
   Dir[f.expand_path(f.join(f.dirname(__FILE__),'lib', 'slanger', '*.rb'))].each do |file|


### PR DESCRIPTION
 prevents warnings with eventmachine 1.0.8

bin/slanger:103: warning: kqueue is not supported on this platform
slanger.rb:13: warning: kqueue is not supported on this platform
lib/slanger/web_socket_server.rb:8: warning: kqueue is not supported on this platform
