### PR TITLE
Add client-event webhook support

### DIFF
--- a/lib/slanger/channel.rb
+++ b/lib/slanger/channel.rb
@@ -83,6 +83,14 @@ module Slanger
     # which will send it to subscribed clients.
     def dispatch(message, channel)
       push(Oj.dump(message, mode: :compat)) unless channel =~ /\Aslanger:/
+
+      if (message['event'].start_with?('client-')) then
+
+        event = message.merge({'name' => 'client_event'})
+        event['data'] = Oj.dump(event['data'])
+
+        Slanger::Webhook.post(event)
+      end
     end
 
     def authenticated?


### PR DESCRIPTION
This satisfies the request in #201 

See: https://pusher.com/docs/client_api_guide/client_events#trigger-events

I apologize if this isn't quite Ruby-idiomatic, but it adds the necessary functionality and I verified it works with our production code as a drop in replacement for Pusher's official implementation.

If you approve the merge it would be a big help if you could deploy a new version to rubygems.