### PR TITLE
Tooling improvements: .gitingore and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# YML requires spaces
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 coverage/
 tmp/
 pkg
+
+/.bundle/
+/vendor/bundle
+.ruby-version


### PR DESCRIPTION
Second of broken up PRs for #215.
- ignore vendor bundle and .ruby-version
- add .editorconfig to help ensure tabs vs spaces convention

I hope the .gitignore changes are acceptable, let me know what you think.

Here is my pitch for editorconfig: developers work on different projects with different coding conventions and formatting. For example, my jobs projects all use the smart tabs style in our code. Checking in .editorconfig lets us switch between projects without having to manually setup each project correctly.

.editorconfig is an opensource spec (http://editorconfig.org/) and is supported natively by GitHub, IntelliJ's editors, and a few other editors, and there are plugins for all the other popular editors. If the file had been committed earlier, and the developer who edited the `Oj` dependency in the gemspec file had been using a compatible editor, that line wouldn't have been added with tabs.

Its a small file and might help prevent some code-style drift, so I say it can't hurt anything.
